### PR TITLE
Fix listener loop dying on ChannelClosedException (whole-server UDP DoS)

### DIFF
--- a/src/Impostor.Server/Net/Hazel/ResilientUdpConnectionListener.cs
+++ b/src/Impostor.Server/Net/Hazel/ResilientUdpConnectionListener.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Impostor.Hazel;
+using Impostor.Hazel.Udp;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Impostor.Server.Net.Hazel
+{
+    /// <summary>
+    ///     A <see cref="UdpConnectionListener"/> that never lets a single packet take down the
+    ///     whole listen loop.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         In the upstream Impostor.Hazel listener, the <c>catch</c> that logs "Listen loop error"
+    ///         sits OUTSIDE the receive <c>while</c> loop. If <see cref="ProcessData"/> throws, the
+    ///         exception unwinds the whole loop, gets logged once, and the listen task ends — there is
+    ///         no restart, so the single shared UDP socket stops receiving for every lobby on the
+    ///         server until the process is restarted.
+    ///     </para>
+    ///     <para>
+    ///         The realistic trigger is a race: <c>ProcessData</c> fetches a connection from the
+    ///         dictionary and then awaits a write to that connection's channel
+    ///         (<c>Pipeline.Writer.WriteAsync</c>). If the connection is concurrently disposed
+    ///         (a kick/leave/keep-alive timeout completes the channel) in the window between the two,
+    ///         the write throws <see cref="System.Threading.Channels.ChannelClosedException"/>. Because
+    ///         UDP is connectionless, in-flight packets from a just-disconnected client keep arriving,
+    ///         so the window is reachable in normal operation and can also be hit deliberately by a
+    ///         client that disconnects and floods packets from the same endpoint.
+    ///     </para>
+    ///     <para>
+    ///         Wrapping the <c>ProcessData</c> call per packet keeps the loop alive on any per-packet
+    ///         failure — matching the original willardf/Hazel-Networking behaviour, which catches
+    ///         around each message and continues. The dropped packet is harmless: it targets a
+    ///         connection that is already gone, and UDP makes no delivery guarantee anyway.
+    ///     </para>
+    /// </remarks>
+    internal sealed class ResilientUdpConnectionListener : UdpConnectionListener
+    {
+        private readonly ILogger<ResilientUdpConnectionListener> _logger;
+
+        public ResilientUdpConnectionListener(
+            IPEndPoint endPoint,
+            ObjectPool<MessageReader> readerPool,
+            ILogger<ResilientUdpConnectionListener> logger,
+            IPMode ipMode = IPMode.IPv4)
+            : base(endPoint, readerPool, ipMode)
+        {
+            _logger = logger;
+        }
+
+        protected override async ValueTask ProcessData(UdpReceiveResult data)
+        {
+            try
+            {
+                await base.ProcessData(data);
+            }
+            catch (System.Threading.Channels.ChannelClosedException)
+            {
+                // The target connection was disposed while this packet was in flight. Expected for
+                // UDP; drop the packet and keep the listen loop running. Not logged: an attacker
+                // could otherwise flood the log by racing disconnects against packet bursts.
+            }
+            catch (System.Exception ex)
+            {
+                // Never let a single malformed/racing packet take down the shared listen loop.
+                _logger.LogWarning(ex, "Dropped UDP packet from {EndPoint} due to an error while processing", data.RemoteEndPoint);
+            }
+        }
+    }
+}

--- a/src/Impostor.Server/Net/Matchmaker.cs
+++ b/src/Impostor.Server/Net/Matchmaker.cs
@@ -21,6 +21,7 @@ namespace Impostor.Server.Net
         private readonly ClientManager _clientManager;
         private readonly ObjectPool<MessageReader> _readerPool;
         private readonly ILogger<HazelConnection> _connectionLogger;
+        private readonly ILogger<ResilientUdpConnectionListener> _listenerLogger;
         private readonly OriginalEndpointTracker _originalEndpointTracker;
         private UdpConnectionListener? _connection;
 
@@ -29,12 +30,14 @@ namespace Impostor.Server.Net
             ClientManager clientManager,
             ObjectPool<MessageReader> readerPool,
             ILogger<HazelConnection> connectionLogger,
+            ILogger<ResilientUdpConnectionListener> listenerLogger,
             OriginalEndpointTracker originalEndpointTracker)
         {
             _eventManager = eventManager;
             _clientManager = clientManager;
             _readerPool = readerPool;
             _connectionLogger = connectionLogger;
+            _listenerLogger = listenerLogger;
             _originalEndpointTracker = originalEndpointTracker;
         }
 
@@ -47,7 +50,7 @@ namespace Impostor.Server.Net
                 _ => throw new InvalidOperationException(),
             };
 
-            _connection = new UdpConnectionListener(ipEndPoint, _readerPool, mode)
+            _connection = new ResilientUdpConnectionListener(ipEndPoint, _readerPool, _listenerLogger, mode)
             {
                 NewConnection = OnNewConnection,
             };


### PR DESCRIPTION
## 概要

共有UDPリスナーループが `ChannelClosedException` 1発で**永久停止**し、サーバー全体（全ロビー）が再起動までUDPパケットを受信できなくなるバグを修正します。

実ログでの発火例:
```
[INF] CANNON - Player ... kept connection open after leaving, disposing.
[INF] Client ... disconnecting, reason: Kicked, detail: Removed from this lobby.
[ERR] Listen loop error
System.Threading.Channels.ChannelClosedException: The channel has been closed.
   at Impostor.Hazel.Udp.UdpConnectionListener.ProcessData(UdpReceiveResult data)
   at Impostor.Hazel.Udp.UdpConnectionListener.ListenAsync()
```

## 原因

`Impostor.Hazel` の `UdpConnectionListener` では、受信 `while` ループを囲む try/catch が**ループの外側**にあります。`ProcessData` が例外を投げるとループ全体が巻き戻り、`"Listen loop error"` を1回ログして `ListenAsync` が終了します。**再起動の仕組みがなく**、リスナーは共有UDPソケット1個につき1ループのため、サーバー上の全ロビーがパケット受信不能になります。

トリガーは `ProcessData` 内のレース:
1. 辞書から接続を取得（`TryGetValue`）
2. `await client.Pipeline.Writer.WriteAsync(...)`

この①②の隙間で当該接続が破棄される（kick / 退出 / keep-alive タイムアウトが `Pipeline.Writer.Complete()` を呼ぶ）と、②が閉鎖済みチャネルへの書き込みとなり `ChannelClosedException` を投げます。UDPはコネクションレスのため、切断直後のクライアントの在庫パケットが届き続け、この窓は**通常運用でも到達可能**（上記ログがまさにその例）であり、同一エンドポイントから切断→パケット連射する悪意あるクライアントが**意図的に誘発**することも可能です。

## 修正内容

`ResilientUdpConnectionListener`（`UdpConnectionListener` の薄いサブクラス）を追加し、`ProcessData` の呼び出しを**パケット単位で try/catch**します。1パケットの失敗で共有ループが落ちることがなくなります。これは元の willardf/Hazel-Networking が各メッセージを catch して継続する挙動と同等です。

- `ChannelClosedException` → **無言で破棄**（UDPでは想定内。ログ出力すると攻撃者がログを洪水にできるため意図的に黙殺）
- その他の例外 → 1パケット分だけ `LogWarning` してループ継続

## 変更ファイル

- `src/Impostor.Server/Net/Hazel/ResilientUdpConnectionListener.cs`（新規）
- `src/Impostor.Server/Net/Matchmaker.cs`（リスナー生成を差し替え＋サブクラス用 `ILogger` を注入）

NuGetパッケージ（`Impostor.Hazel`）側のコードには手を入れず、サーバー側のサブクラスで上書きする最小差分です。csproj / sln / DI登録の変更はありません。

## 性能への影響

ほぼ中立。正常パケットは .NET の zero-cost try によりコスト増なし、サブクラス1段の仮想呼び出しのみ。

## 補足

根本修正（`ListenAsync` のループ内 try/catch ＋ `WriteAsync`→`TryWrite`）は上流 `Impostor/Impostor.Hazel` 側で行うのが本筋ですが、private メンバへアクセスできないためサブクラスからは `TryWrite` 化はできません。本PRはフォークのビルドに即座に効く止血策です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
